### PR TITLE
Add angular support

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -44,6 +44,10 @@ inputs:
     required: false
     description: 'Additional environment variables set in the workflow (in the JSON format)'
 
+  dist_path:
+    required: false
+    description: 'Path to dist folder. If not defined, a path based on framework will be used.'
+
   # vault:
   VAULT_ADDR:
     required: false
@@ -84,6 +88,7 @@ runs:
         ssr: ${{ inputs.ssr }}
         package_manager: ${{ inputs.package_manager }}
         newrelic: ${{ inputs.newrelic }}
+        dist_path: ${{ inputs.dist_path }}
     - name: 'Bootstrap up the Node.js environment'
       uses: infinum/js-pipeline/.github/actions/bootstrap@master
       with:

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -81,7 +81,7 @@ runs:
     - name: Git checkout
       uses: actions/checkout@v3
     - name: Detect env
-      uses: infinum/js-pipeline/.github/actions/detect-env@master
+      uses: infinum/js-pipeline/.github/actions/detect-env@add-angular-support
       with:
         runner: ${{ inputs.runner }}
         framework: ${{ inputs.framework }}
@@ -90,7 +90,7 @@ runs:
         newrelic: ${{ inputs.newrelic }}
         dist_path: ${{ inputs.dist_path }}
     - name: 'Bootstrap up the Node.js environment'
-      uses: infinum/js-pipeline/.github/actions/bootstrap@master
+      uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
       with:
         runner: ${{ inputs.runner }}
         package_manager: ${{ env.package_manager }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -81,7 +81,7 @@ runs:
     - name: Git checkout
       uses: actions/checkout@v3
     - name: Detect env
-      uses: infinum/js-pipeline/.github/actions/detect-env@add-angular-support
+      uses: infinum/js-pipeline/.github/actions/detect-env@v1
       with:
         runner: ${{ inputs.runner }}
         framework: ${{ inputs.framework }}
@@ -90,7 +90,7 @@ runs:
         newrelic: ${{ inputs.newrelic }}
         dist_path: ${{ inputs.dist_path }}
     - name: 'Bootstrap up the Node.js environment'
-      uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
+      uses: infinum/js-pipeline/.github/actions/bootstrap@v1
       with:
         runner: ${{ inputs.runner }}
         package_manager: ${{ env.package_manager }}

--- a/.github/actions/detect-env/action.yml
+++ b/.github/actions/detect-env/action.yml
@@ -80,7 +80,7 @@ runs:
     - name: Detect build path
       shell: bash
       run: |
-        if [ "${{ inputs.dist_path }}" != ""]; then
+        if "${{ inputs.dist_path != '' }}"; then
           echo "dist_path=${{ inputs.dist_path }}" >> $GITHUB_ENV
           echo "artifact_path=${{ inputs.dist_path }}" >> $GITHUB_ENV
         elif [ "${{ env.framework }}" == "next" ]; then

--- a/.github/actions/detect-env/action.yml
+++ b/.github/actions/detect-env/action.yml
@@ -80,7 +80,7 @@ runs:
     - name: Detect build path
       shell: bash
       run: |
-        if [${{ inputs.dist_path}} != '']; then
+        if [ "${{ inputs.dist_path }}" != ""]; then
           echo "dist_path=${{ inputs.dist_path }}" >> $GITHUB_ENV
           echo "artifact_path=${{ inputs.dist_path }}" >> $GITHUB_ENV
         elif [ "${{ env.framework }}" == "next" ]; then

--- a/.github/actions/detect-env/action.yml
+++ b/.github/actions/detect-env/action.yml
@@ -79,6 +79,7 @@ runs:
         fi
     - name: Detect build path
       shell: bash
+      # This needs to be adjusted to include SSR condition
       run: |
         if "${{ inputs.dist_path != '' }}"; then
           echo "dist_path=${{ inputs.dist_path }}" >> $GITHUB_ENV

--- a/.github/actions/detect-env/action.yml
+++ b/.github/actions/detect-env/action.yml
@@ -79,10 +79,8 @@ runs:
         fi
     - name: Detect build path
       shell: bash
-      # String assignments ./ ?
-      # Maybe add another input for artifact path and add logical OR in expressions?
       run: |
-        if ${{ inputs.dist_path }}; then
+        if ${{ inputs.dist_path || false }}; then
           echo "dist_path=${{ inputs.dist_path }}" >> $GITHUB_ENV
           echo "artifact_path=${{ inputs.dist_path }}" >> $GITHUB_ENV
         elif [ "${{ env.framework }}" == "next" ]; then

--- a/.github/actions/detect-env/action.yml
+++ b/.github/actions/detect-env/action.yml
@@ -37,7 +37,7 @@ runs:
     - name: Detect framework
       shell: bash
       run: |
-        if ${{ inputs.framework || false }}; then
+        if ${{ inputs.framework != '' }}; then
           echo "framework=${{ inputs.framework }}" >> $GITHUB_ENV
         elif [ -f angular.json ]; then
           echo "framework=angular" >> $GITHUB_ENV
@@ -50,7 +50,7 @@ runs:
     - name: Detect SSR
       shell: bash
       run: |
-        if ${{ inputs.ssr || false }}; then
+        if ${{ inputs.ssr != '' }}; then
           echo "ssr=${{ inputs.ssr }}" >> $GITHUB_ENV
         elif [ -f next.config.js ]; then
           echo "ssr=true" >> $GITHUB_ENV
@@ -60,7 +60,7 @@ runs:
     - name: Detect package manager
       shell: bash
       run: |
-        if ${{ inputs.package_manager || false }}; then
+        if ${{ inputs.package_manager != '' }}; then
           echo "package_manager=${{ inputs.package_manager }}" >> $GITHUB_ENV
         elif [ -f package-lock.json ]; then
           echo "package_manager=npm" >> $GITHUB_ENV
@@ -70,7 +70,7 @@ runs:
     - name: Detect tooling
       shell: bash
       run: |
-        if ${{ inputs.newrelic || false }}; then
+        if ${{ inputs.newrelic != '' }}; then
           echo "newrelic=${{ inputs.newrelic }}" >> $GITHUB_ENV
         elif [ -f newrelic.js ]; then
           echo "newrelic=true" >> $GITHUB_ENV
@@ -79,12 +79,11 @@ runs:
         fi
     - name: Detect build path
       shell: bash
-      # This needs to be adjusted to include SSR condition
       run: |
         if "${{ inputs.dist_path != '' }}"; then
           echo "dist_path=${{ inputs.dist_path }}" >> $GITHUB_ENV
           echo "artifact_path=${{ inputs.dist_path }}" >> $GITHUB_ENV
-        elif [ "${{ env.framework }}" == "next" ]; then
+        elif [ "${{ env.framework }}" == "next" && ${{ env.ssr }} == true ]; then
           echo "dist_path=.next/standalone/" >> $GITHUB_ENV
           echo "artifact_path=./next/**" >> $GITHUB_ENV
         elif [ ${{ env.framework }}  == "node" ]; then

--- a/.github/actions/detect-env/action.yml
+++ b/.github/actions/detect-env/action.yml
@@ -80,7 +80,7 @@ runs:
     - name: Detect build path
       shell: bash
       run: |
-        if ${{ inputs.dist_path || false }}; then
+        if [${{ inputs.dist_path}} != '']; then
           echo "dist_path=${{ inputs.dist_path }}" >> $GITHUB_ENV
           echo "artifact_path=${{ inputs.dist_path }}" >> $GITHUB_ENV
         elif [ "${{ env.framework }}" == "next" ]; then

--- a/.github/actions/detect-env/action.yml
+++ b/.github/actions/detect-env/action.yml
@@ -25,6 +25,10 @@ inputs:
     required: false
     description: 'Should New Relic be used? If not defined, use New Relic if `newrelic.js` is present, otherwise do not use New Relic'
 
+  dist_path:
+    required: false
+    description: 'Path to dist folder. If not defined, a path based on framework will be used.'
+
 runs:
   using: 'composite'
   steps:
@@ -73,6 +77,24 @@ runs:
         else
           echo "newrelic=false" >> $GITHUB_ENV
         fi
+    - name: Detect build path
+      shell: bash
+      # String assignments ./ ?
+      # Maybe add another input for artifact path and add logical OR in expressions?
+      run: |
+        if ${{ inputs.dist_path }}; then
+          echo "dist_path=${{ inputs.dist_path }}" >> $GITHUB_ENV
+          echo "artifact_path=${{ inputs.dist_path }}" >> $GITHUB_ENV
+        elif [ "${{ env.framework }}" == "next" ]; then
+          echo "dist_path=.next/standalone/" >> $GITHUB_ENV
+          echo "artifact_path=./next/**" >> $GITHUB_ENV
+        elif [ ${{ env.framework }}  == "node" ]; then
+          echo "dist_path=./" >> $GITHUB_ENV
+          echo "artifact_path=./" >> $GITHUB_ENV
+        else
+          echo "dist_path=./dist/*" >> $GITHUB_ENV
+          echo "artifact_path=./dist/*" >> $GITHUB_ENV
+        fi
     - name: Summary
       shell: bash
       run: |
@@ -80,3 +102,5 @@ runs:
         echo "SSR: ${{ env.ssr }}"
         echo "Package manager: ${{ env.package_manager }}"
         echo "New Relic: ${{ env.newrelic }}"
+        echo "dist_path: ${{ env.dist_path }}"
+        echo "artifact_path": ${{ env.artifact_path }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Detect env
-        uses: infinum/js-pipeline/.github/actions/detect-env@add-angular-support
+        uses: infinum/js-pipeline/.github/actions/detect-env@v1
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}
@@ -152,7 +152,7 @@ jobs:
           newrelic: ${{ inputs.newrelic }}
           dist_path: ${{ inputs.dist_path }}
       - name: 'Bootstrap up the Node.js environment'
-        uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
+        uses: infinum/js-pipeline/.github/actions/bootstrap@v1
         with:
           runner: ${{ inputs.runner }}
           package_manager: ${{ env.package_manager }}
@@ -168,7 +168,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Build
-        uses: infinum/js-pipeline/.github/actions/build@add-angular-support
+        uses: infinum/js-pipeline/.github/actions/build@v1
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}
@@ -210,7 +210,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Detect env
-        uses: infinum/js-pipeline/.github/actions/detect-env@add-angular-support
+        uses: infinum/js-pipeline/.github/actions/detect-env@v1
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}
@@ -218,7 +218,7 @@ jobs:
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
       - name: 'Bootstrap up the Node.js environment'
-        uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
+        uses: infinum/js-pipeline/.github/actions/bootstrap@v1
         with:
           runner: ${{ inputs.runner }}
           package_manager: ${{ env.package_manager }}
@@ -238,7 +238,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Detect env
-        uses: infinum/js-pipeline/.github/actions/detect-env@add-angular-support
+        uses: infinum/js-pipeline/.github/actions/detect-env@v1
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}
@@ -246,7 +246,7 @@ jobs:
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
       - name: 'Bootstrap up the Node.js environment'
-        uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
+        uses: infinum/js-pipeline/.github/actions/bootstrap@v1
         with:
           runner: ${{ inputs.runner }}
           package_manager: ${{ env.package_manager }}
@@ -266,7 +266,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Detect env
-        uses: infinum/js-pipeline/.github/actions/detect-env@add-angular-support
+        uses: infinum/js-pipeline/.github/actions/detect-env@v1
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}
@@ -274,7 +274,7 @@ jobs:
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
       - name: 'Bootstrap up the Node.js environment'
-        uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
+        uses: infinum/js-pipeline/.github/actions/bootstrap@v1
         with:
           runner: ${{ inputs.runner }}
           package_manager: ${{ env.package_manager }}
@@ -297,7 +297,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: 'Analyze the bundle'
-        uses: infinum/js-pipeline/.github/actions/analyze@add-angular-support
+        uses: infinum/js-pipeline/.github/actions/analyze@v1
         with:
           workflow: ${{ inputs.workflow }}
   deploy:
@@ -309,7 +309,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Detect env
-        uses: infinum/js-pipeline/.github/actions/detect-env@add-angular-support
+        uses: infinum/js-pipeline/.github/actions/detect-env@v1
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}
@@ -318,7 +318,7 @@ jobs:
           newrelic: ${{ inputs.newrelic }}
 
       - name: Build
-        uses: infinum/js-pipeline/.github/actions/build@add-angular-support
+        uses: infinum/js-pipeline/.github/actions/build@v1
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -360,21 +360,7 @@ jobs:
           script: |
             mkdir -p ~/www/${{ inputs.deploy_host }}/releases/${{ steps.commit.outputs.short }}
 
-      # Test if this is needed as detect-env is now handling the path
-      # - name: Copy deployment for Next.js
-      #   if: ${{ env.framework == 'next' && env.ssr == 'true' }}
-      #   uses: burnett01/rsync-deployments@5.2.1
-      #   with:
-      #     switches: -avzr
-      #     path: ${{ env.dist_path }}
-      #     remote_path: /home/${{ inputs.deploy_user }}/www/${{ inputs.deploy_host }}/releases/${{ steps.commit.outputs.short }}/
-      #     remote_host: ${{ inputs.deploy_host }}
-      #     remote_port: ${{ inputs.deploy_port }}
-      #     remote_user: ${{ inputs.deploy_user }}
-      #     remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      - name: Copy deployment for other
-        # if: ${{ env.framework != 'next' || env.ssr == 'false' }}
+      - name: Copy deployment
         uses: burnett01/rsync-deployments@5.2.1
         with:
           switches: -avzr
@@ -384,17 +370,6 @@ jobs:
           remote_port: ${{ inputs.deploy_port }}
           remote_user: ${{ inputs.deploy_user }}
           remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      # Test if this is needed, it just cd-s
-      # - name: Deploy to ${{ inputs.environment }}
-      #   uses: appleboy/ssh-action@v0.1.6
-      #   with:
-      #     host: ${{ inputs.deploy_host }}
-      #     username: ${{ inputs.deploy_user }}
-      #     key: ${{ secrets.SSH_PRIVATE_KEY }}
-      #     port: ${{ inputs.deploy_port }}
-      #     script: |
-      #       cd ~/www/${{ inputs.deploy_host }}/releases/${{ steps.commit.outputs.short }}
 
       - name: Deploy the release
         uses: appleboy/ssh-action@v0.1.6

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -110,6 +110,10 @@ on:
         type: string
         default: 'https://i.imgur.com/v6bLyxF.png'
 
+      dist_path:
+        required: false
+        type: string
+
     secrets:
       VAULT_ADDR:
         required: false
@@ -145,6 +149,7 @@ jobs:
           ssr: ${{ inputs.ssr }}
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
+          dist_path: ${{ inputs.dist_path }}
       - name: 'Bootstrap up the Node.js environment'
         uses: infinum/js-pipeline/.github/actions/bootstrap@v1
         with:
@@ -173,6 +178,7 @@ jobs:
           environment: ${{ inputs.environment }}
           secrets: ${{ inputs.secrets }}
           env_vars: ${{ secrets.ADDITIONAL_VARIABLES }}
+          dist_path: ${{ inputs.dist_path }}
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           VAULT_AUTH_METHOD: ${{ secrets.VAULT_AUTH_METHOD }}
           VAULT_AUTH_SECRET_ID: ${{ secrets.VAULT_AUTH_SECRET_ID }}
@@ -187,7 +193,13 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: 'build'
-          path: .next/**
+          path: ${{ env.artifact_path }}
+      - name: Generic upload artifacts
+        if: ${{ env.framework != 'next' || env.ssr == 'false' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'build'
+          path: ${{ env.dist_path }}
   lint:
     needs: [setup]
     name: 'Lint the code'
@@ -322,6 +334,7 @@ jobs:
           environment: ${{ inputs.environment }}
           secrets: ${{ inputs.secrets }}
           env_vars: ${{ secrets.ADDITIONAL_VARIABLES }}
+          dist_path: ${{ inputs.dist_path }}
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           VAULT_AUTH_METHOD: ${{ secrets.VAULT_AUTH_METHOD }}
           VAULT_AUTH_ROLE_ID: ${{ secrets.VAULT_AUTH_ROLE_ID }}
@@ -357,7 +370,7 @@ jobs:
         uses: burnett01/rsync-deployments@5.2.1
         with:
           switches: -avzr
-          path: .next/standalone/
+          path: ${{ env.dist_path }}
           remote_path: /home/${{ inputs.deploy_user }}/www/${{ inputs.deploy_host }}/releases/${{ steps.commit.outputs.short }}/
           remote_host: ${{ inputs.deploy_host }}
           remote_port: ${{ inputs.deploy_port }}
@@ -369,7 +382,7 @@ jobs:
         uses: burnett01/rsync-deployments@5.2.1
         with:
           switches: -avzr
-          path: .
+          path: ${{ env.dist_path }}
           remote_path: /home/${{ inputs.deploy_user }}/www/${{ inputs.deploy_host }}/releases/${{ steps.commit.outputs.short }}/
           remote_host: ${{ inputs.deploy_host }}
           remote_port: ${{ inputs.deploy_port }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -14,6 +14,7 @@ on:
         type: string
         default: ubuntu-latest
 
+      # Used for accessing environment specific secrets vault and Slack integration messages
       environment:
         required: true
         type: string
@@ -60,7 +61,7 @@ on:
       notify_on:
         required: false
         type: string
-        default: "all"
+        default: 'all'
 
       # Steps that should be executed during build
       # Valid values:
@@ -108,7 +109,7 @@ on:
       project_icon:
         required: false
         type: string
-        default: "https://i.imgur.com/v6bLyxF.png"
+        default: 'https://i.imgur.com/v6bLyxF.png'
 
       dist_path:
         required: false
@@ -136,7 +137,7 @@ on:
 
 jobs:
   setup:
-    name: "Environment setup"
+    name: 'Environment setup'
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Git checkout
@@ -150,7 +151,7 @@ jobs:
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
           dist_path: ${{ inputs.dist_path }}
-      - name: "Bootstrap up the Node.js environment"
+      - name: 'Bootstrap up the Node.js environment'
         uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
         with:
           runner: ${{ inputs.runner }}
@@ -160,7 +161,7 @@ jobs:
           env_vars: ${{ secrets.ADDITIONAL_VARIABLES }}
   build:
     needs: [setup]
-    name: "Build"
+    name: 'Build'
     if: ${{ contains(inputs.ci_steps, 'build') || contains(inputs.ci_steps, 'analyze') }}
     runs-on: ${{ inputs.runner }}
     steps:
@@ -186,23 +187,23 @@ jobs:
       - name: Prepare artifact for Next.js
         shell: bash
         if: ${{ env.framework == 'next' }}
-        id: "prepare-artifact"
-        run: "rm -rf .next/cache"
+        id: 'prepare-artifact'
+        run: 'rm -rf .next/cache'
       - name: Upload artifacts for Next.js
         if: ${{ env.framework == 'next' }}
         uses: actions/upload-artifact@v3
         with:
-          name: "build"
+          name: 'build'
           path: ${{ env.artifact_path }}
       - name: Generic upload artifacts
         if: ${{ env.framework != 'next' || env.ssr == 'false' }}
         uses: actions/upload-artifact@v3
         with:
-          name: "build"
+          name: 'build'
           path: ${{ env.dist_path }}
   lint:
     needs: [setup]
-    name: "Lint the code"
+    name: 'Lint the code'
     if: ${{ contains(inputs.ci_steps, 'lint') }}
     runs-on: ${{ inputs.runner }}
     steps:
@@ -216,7 +217,7 @@ jobs:
           ssr: ${{ inputs.ssr }}
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
-      - name: "Bootstrap up the Node.js environment"
+      - name: 'Bootstrap up the Node.js environment'
         uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
         with:
           runner: ${{ inputs.runner }}
@@ -226,11 +227,11 @@ jobs:
           env_vars: ${{ secrets.ADDITIONAL_VARIABLES }}
       - name: Run lint
         shell: bash
-        id: "lint"
-        run: "npm run lint"
+        id: 'lint'
+        run: 'npm run lint'
   test:
     needs: [setup]
-    name: "Run tests"
+    name: 'Run tests'
     if: ${{ contains(inputs.ci_steps, 'test') }}
     runs-on: ${{ inputs.runner }}
     steps:
@@ -244,7 +245,7 @@ jobs:
           ssr: ${{ inputs.ssr }}
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
-      - name: "Bootstrap up the Node.js environment"
+      - name: 'Bootstrap up the Node.js environment'
         uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
         with:
           runner: ${{ inputs.runner }}
@@ -254,11 +255,11 @@ jobs:
           env_vars: ${{ secrets.ADDITIONAL_VARIABLES }}
       - name: Run test
         shell: bash
-        id: "test"
-        run: "npm run test"
+        id: 'test'
+        run: 'npm run test'
   jest:
     needs: [setup]
-    name: "Run tests with coverage"
+    name: 'Run tests with coverage'
     if: ${{ contains(inputs.ci_steps, 'jest') }}
     runs-on: ${{ inputs.runner }}
     steps:
@@ -272,7 +273,7 @@ jobs:
           ssr: ${{ inputs.ssr }}
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
-      - name: "Bootstrap up the Node.js environment"
+      - name: 'Bootstrap up the Node.js environment'
         uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
         with:
           runner: ${{ inputs.runner }}
@@ -289,19 +290,19 @@ jobs:
           delta: 0.5
   analyze:
     needs: [build]
-    name: "Analyze the Next.js bundle size"
+    name: 'Analyze the Next.js bundle size'
     if: ${{ contains(inputs.ci_steps, 'analyze') }}
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
-      - name: "Analyze the bundle"
+      - name: 'Analyze the bundle'
         uses: infinum/js-pipeline/.github/actions/analyze@add-angular-support
         with:
           workflow: ${{ inputs.workflow }}
   deploy:
     needs: [setup]
-    name: "Deploy the application"
+    name: 'Deploy the application'
     if: ${{ contains(inputs.ci_steps, 'deploy') }}
     runs-on: ${{ inputs.runner }}
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -60,7 +60,7 @@ on:
       notify_on:
         required: false
         type: string
-        default: 'all'
+        default: "all"
 
       # Steps that should be executed during build
       # Valid values:
@@ -108,7 +108,7 @@ on:
       project_icon:
         required: false
         type: string
-        default: 'https://i.imgur.com/v6bLyxF.png'
+        default: "https://i.imgur.com/v6bLyxF.png"
 
       dist_path:
         required: false
@@ -136,7 +136,7 @@ on:
 
 jobs:
   setup:
-    name: 'Environment setup'
+    name: "Environment setup"
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Git checkout
@@ -150,7 +150,7 @@ jobs:
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
           dist_path: ${{ inputs.dist_path }}
-      - name: 'Bootstrap up the Node.js environment'
+      - name: "Bootstrap up the Node.js environment"
         uses: infinum/js-pipeline/.github/actions/bootstrap@v1
         with:
           runner: ${{ inputs.runner }}
@@ -160,7 +160,7 @@ jobs:
           env_vars: ${{ secrets.ADDITIONAL_VARIABLES }}
   build:
     needs: [setup]
-    name: 'Build'
+    name: "Build"
     if: ${{ contains(inputs.ci_steps, 'build') || contains(inputs.ci_steps, 'analyze') }}
     runs-on: ${{ inputs.runner }}
     steps:
@@ -186,23 +186,23 @@ jobs:
       - name: Prepare artifact for Next.js
         shell: bash
         if: ${{ env.framework == 'next' }}
-        id: 'prepare-artifact'
-        run: 'rm -rf .next/cache'
+        id: "prepare-artifact"
+        run: "rm -rf .next/cache"
       - name: Upload artifacts for Next.js
         if: ${{ env.framework == 'next' }}
         uses: actions/upload-artifact@v3
         with:
-          name: 'build'
+          name: "build"
           path: ${{ env.artifact_path }}
       - name: Generic upload artifacts
         if: ${{ env.framework != 'next' || env.ssr == 'false' }}
         uses: actions/upload-artifact@v3
         with:
-          name: 'build'
+          name: "build"
           path: ${{ env.dist_path }}
   lint:
     needs: [setup]
-    name: 'Lint the code'
+    name: "Lint the code"
     if: ${{ contains(inputs.ci_steps, 'lint') }}
     runs-on: ${{ inputs.runner }}
     steps:
@@ -216,7 +216,7 @@ jobs:
           ssr: ${{ inputs.ssr }}
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
-      - name: 'Bootstrap up the Node.js environment'
+      - name: "Bootstrap up the Node.js environment"
         uses: infinum/js-pipeline/.github/actions/bootstrap@v1
         with:
           runner: ${{ inputs.runner }}
@@ -226,11 +226,11 @@ jobs:
           env_vars: ${{ secrets.ADDITIONAL_VARIABLES }}
       - name: Run lint
         shell: bash
-        id: 'lint'
-        run: 'npm run lint'
+        id: "lint"
+        run: "npm run lint"
   test:
     needs: [setup]
-    name: 'Run tests'
+    name: "Run tests"
     if: ${{ contains(inputs.ci_steps, 'test') }}
     runs-on: ${{ inputs.runner }}
     steps:
@@ -244,7 +244,7 @@ jobs:
           ssr: ${{ inputs.ssr }}
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
-      - name: 'Bootstrap up the Node.js environment'
+      - name: "Bootstrap up the Node.js environment"
         uses: infinum/js-pipeline/.github/actions/bootstrap@v1
         with:
           runner: ${{ inputs.runner }}
@@ -254,11 +254,11 @@ jobs:
           env_vars: ${{ secrets.ADDITIONAL_VARIABLES }}
       - name: Run test
         shell: bash
-        id: 'test'
-        run: 'npm run test'
+        id: "test"
+        run: "npm run test"
   jest:
     needs: [setup]
-    name: 'Run tests with coverage'
+    name: "Run tests with coverage"
     if: ${{ contains(inputs.ci_steps, 'jest') }}
     runs-on: ${{ inputs.runner }}
     steps:
@@ -272,7 +272,7 @@ jobs:
           ssr: ${{ inputs.ssr }}
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
-      - name: 'Bootstrap up the Node.js environment'
+      - name: "Bootstrap up the Node.js environment"
         uses: infinum/js-pipeline/.github/actions/bootstrap@v1
         with:
           runner: ${{ inputs.runner }}
@@ -289,19 +289,19 @@ jobs:
           delta: 0.5
   analyze:
     needs: [build]
-    name: 'Analyze the Next.js bundle size'
+    name: "Analyze the Next.js bundle size"
     if: ${{ contains(inputs.ci_steps, 'analyze') }}
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
-      - name: 'Analyze the bundle'
+      - name: "Analyze the bundle"
         uses: infinum/js-pipeline/.github/actions/analyze@v1
         with:
           workflow: ${{ inputs.workflow }}
   deploy:
     needs: [setup]
-    name: 'Deploy the application'
+    name: "Deploy the application"
     if: ${{ contains(inputs.ci_steps, 'deploy') }}
     runs-on: ${{ inputs.runner }}
     steps:
@@ -315,12 +315,6 @@ jobs:
           ssr: ${{ inputs.ssr }}
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
-
-      - name: Check unsupported
-        if: ${{ env.ssr == 'false' && env.framework != 'node' }}
-        run: |
-          echo "Only SSR and Node apps are currently supported for deployment"
-          exit 1
 
       - name: Build
         uses: infinum/js-pipeline/.github/actions/build@v1

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -360,20 +360,21 @@ jobs:
           script: |
             mkdir -p ~/www/${{ inputs.deploy_host }}/releases/${{ steps.commit.outputs.short }}
 
-      - name: Copy deployment for Next.js
-        if: ${{ env.framework == 'next' && env.ssr == 'true' }}
-        uses: burnett01/rsync-deployments@5.2.1
-        with:
-          switches: -avzr
-          path: ${{ env.dist_path }}
-          remote_path: /home/${{ inputs.deploy_user }}/www/${{ inputs.deploy_host }}/releases/${{ steps.commit.outputs.short }}/
-          remote_host: ${{ inputs.deploy_host }}
-          remote_port: ${{ inputs.deploy_port }}
-          remote_user: ${{ inputs.deploy_user }}
-          remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
+      # Test if this is needed as detect-env is now handling the path
+      # - name: Copy deployment for Next.js
+      #   if: ${{ env.framework == 'next' && env.ssr == 'true' }}
+      #   uses: burnett01/rsync-deployments@5.2.1
+      #   with:
+      #     switches: -avzr
+      #     path: ${{ env.dist_path }}
+      #     remote_path: /home/${{ inputs.deploy_user }}/www/${{ inputs.deploy_host }}/releases/${{ steps.commit.outputs.short }}/
+      #     remote_host: ${{ inputs.deploy_host }}
+      #     remote_port: ${{ inputs.deploy_port }}
+      #     remote_user: ${{ inputs.deploy_user }}
+      #     remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Copy deployment for other
-        if: ${{ env.framework != 'next' || env.ssr == 'false' }}
+        # if: ${{ env.framework != 'next' || env.ssr == 'false' }}
         uses: burnett01/rsync-deployments@5.2.1
         with:
           switches: -avzr
@@ -384,15 +385,16 @@ jobs:
           remote_user: ${{ inputs.deploy_user }}
           remote_key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: Deploy to ${{ inputs.environment }}
-        uses: appleboy/ssh-action@v0.1.6
-        with:
-          host: ${{ inputs.deploy_host }}
-          username: ${{ inputs.deploy_user }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          port: ${{ inputs.deploy_port }}
-          script: |
-            cd ~/www/${{ inputs.deploy_host }}/releases/${{ steps.commit.outputs.short }}
+      # Test if this is needed, it just cd-s
+      # - name: Deploy to ${{ inputs.environment }}
+      #   uses: appleboy/ssh-action@v0.1.6
+      #   with:
+      #     host: ${{ inputs.deploy_host }}
+      #     username: ${{ inputs.deploy_user }}
+      #     key: ${{ secrets.SSH_PRIVATE_KEY }}
+      #     port: ${{ inputs.deploy_port }}
+      #     script: |
+      #       cd ~/www/${{ inputs.deploy_host }}/releases/${{ steps.commit.outputs.short }}
 
       - name: Deploy the release
         uses: appleboy/ssh-action@v0.1.6

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Detect env
-        uses: infinum/js-pipeline/.github/actions/detect-env@v1
+        uses: infinum/js-pipeline/.github/actions/detect-env@add-angular-support
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}
@@ -151,7 +151,7 @@ jobs:
           newrelic: ${{ inputs.newrelic }}
           dist_path: ${{ inputs.dist_path }}
       - name: "Bootstrap up the Node.js environment"
-        uses: infinum/js-pipeline/.github/actions/bootstrap@v1
+        uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
         with:
           runner: ${{ inputs.runner }}
           package_manager: ${{ env.package_manager }}
@@ -167,7 +167,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Build
-        uses: infinum/js-pipeline/.github/actions/build@v1
+        uses: infinum/js-pipeline/.github/actions/build@add-angular-support
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}
@@ -209,7 +209,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Detect env
-        uses: infinum/js-pipeline/.github/actions/detect-env@v1
+        uses: infinum/js-pipeline/.github/actions/detect-env@add-angular-support
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}
@@ -217,7 +217,7 @@ jobs:
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
       - name: "Bootstrap up the Node.js environment"
-        uses: infinum/js-pipeline/.github/actions/bootstrap@v1
+        uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
         with:
           runner: ${{ inputs.runner }}
           package_manager: ${{ env.package_manager }}
@@ -237,7 +237,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Detect env
-        uses: infinum/js-pipeline/.github/actions/detect-env@v1
+        uses: infinum/js-pipeline/.github/actions/detect-env@add-angular-support
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}
@@ -245,7 +245,7 @@ jobs:
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
       - name: "Bootstrap up the Node.js environment"
-        uses: infinum/js-pipeline/.github/actions/bootstrap@v1
+        uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
         with:
           runner: ${{ inputs.runner }}
           package_manager: ${{ env.package_manager }}
@@ -265,7 +265,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Detect env
-        uses: infinum/js-pipeline/.github/actions/detect-env@v1
+        uses: infinum/js-pipeline/.github/actions/detect-env@add-angular-support
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}
@@ -273,7 +273,7 @@ jobs:
           package_manager: ${{ inputs.package_manager }}
           newrelic: ${{ inputs.newrelic }}
       - name: "Bootstrap up the Node.js environment"
-        uses: infinum/js-pipeline/.github/actions/bootstrap@v1
+        uses: infinum/js-pipeline/.github/actions/bootstrap@add-angular-support
         with:
           runner: ${{ inputs.runner }}
           package_manager: ${{ env.package_manager }}
@@ -296,7 +296,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: "Analyze the bundle"
-        uses: infinum/js-pipeline/.github/actions/analyze@v1
+        uses: infinum/js-pipeline/.github/actions/analyze@add-angular-support
         with:
           workflow: ${{ inputs.workflow }}
   deploy:
@@ -308,7 +308,7 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Detect env
-        uses: infinum/js-pipeline/.github/actions/detect-env@v1
+        uses: infinum/js-pipeline/.github/actions/detect-env@add-angular-support
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}
@@ -317,7 +317,7 @@ jobs:
           newrelic: ${{ inputs.newrelic }}
 
       - name: Build
-        uses: infinum/js-pipeline/.github/actions/build@v1
+        uses: infinum/js-pipeline/.github/actions/build@add-angular-support
         with:
           runner: ${{ inputs.runner }}
           framework: ${{ inputs.framework }}

--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,7 @@ Inputs that may be defined in the workflow file, but have defaults that are usua
 | `node_version` | Node.js version to use. | all | false | The one defined in `.node-version` |
 | `framework` | Project type - supported values are `angular`, `react`, `next` and `node` | all | false | `angular` if `angular.json` present in root, `next` if `next.config.js` present in root, otherwise `react` |
 | `deploy_to` | Path where the app is deployed on the server | `deploy` | false | `/home/{{deploy_user}}/www/{{deploy_host}}` |
+| `dist_path` | Path to build folder | `build, deploy` | false | `./dist/*` |
 | `newrelic` | Should we run server-side newrelic | `deploy` | false | `true` if `newrelic.js` exists in project root, `false` otherwise |
 | `ssr` | Whether to build the app in SSR mode. | `deploy` | false | `true` if framework is next, `false` otherwise |
 | `notify_on` | When to send notifications. Possible values are `success`, `failure` and `all` | `deploy` | false | `all` |


### PR DESCRIPTION
This PR adds support for deploying Angular and other apps. 

- I removed the following as it seems it it only cs-d and doesn't really do anything. Angular deploy was successful without it:
```
uses: appleboy/ssh-action@v0.1.6
        with:
          host: ${{ inputs.deploy_host }}
          username: ${{ inputs.deploy_user }}
          key: ${{ secrets.SSH_PRIVATE_KEY }}
          port: ${{ inputs.deploy_port }}
          script: |
            cd ~/www/${{ inputs.deploy_host }}/releases/${{ steps.commit.outputs.short }}
```

- I have also changed the conditions in `detect-env` action as they weren't working properly.

- Since I had to change the references of actions used to my branch and this PR shouldn't introduce breaking changes, before merging to the V1 branch, those references should be reverted to point back to V1.

- I have tested the Angular deployment on GuessWho staging, @DarkoKukovec Do you have any `next.js` app you could test the changes on?