### PR TITLE
Add timeout input V1

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -115,6 +115,11 @@ on:
         required: false
         type: string
 
+      timeout_minutes:
+        required: false
+        type: number
+        default: 10
+
     secrets:
       VAULT_ADDR:
         required: false
@@ -139,6 +144,7 @@ jobs:
   setup:
     name: 'Environment setup'
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -164,6 +170,7 @@ jobs:
     name: 'Build'
     if: ${{ contains(inputs.ci_steps, 'build') || contains(inputs.ci_steps, 'analyze') }}
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -206,6 +213,7 @@ jobs:
     name: 'Lint the code'
     if: ${{ contains(inputs.ci_steps, 'lint') }}
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -234,6 +242,7 @@ jobs:
     name: 'Run tests'
     if: ${{ contains(inputs.ci_steps, 'test') }}
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -262,6 +271,7 @@ jobs:
     name: 'Run tests with coverage'
     if: ${{ contains(inputs.ci_steps, 'jest') }}
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -293,6 +303,7 @@ jobs:
     name: 'Analyze the Next.js bundle size'
     if: ${{ contains(inputs.ci_steps, 'analyze') }}
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -305,6 +316,7 @@ jobs:
     name: 'Deploy the application'
     if: ${{ contains(inputs.ci_steps, 'deploy') }}
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds support for GH job timeout. The default value is 10 minutes if the `timeout_minutes` input is not set.